### PR TITLE
Revert supported PHP version back to >=7.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ bin
 coverage
 coverage.xml
 .php_cs.cache
+.phpunit.result.cache
 examples/lumen-app/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,62 @@
-dist: precise
-
 language: php
 
-php:
-  - 7.2
+matrix:
+  include:
+    - php: 7.2
+      env: PU_FILE=53
+    - php: 7.2
+      env: PU_FILE=54
+    - php: 7.2
+      env: PU_FILE=55
+    - php: 7.2
+      env: PU_FILE=56
+    - php: 7.2
+      env: PU_FILE=57
+    - php: 7.2
+      env: PU_FILE=58
+    - php: 7.2
+      env: PU_FILE=6
+    - php: 7.2
+      env: PU_FILE=7
+    - php: 7.3
+      env: PU_FILE=54
+    - php: 7.3
+      env: PU_FILE=55
+    - php: 7.3
+      env: PU_FILE=56
+    - php: 7.3
+      env: PU_FILE=57
+    - php: 7.3
+      env: PU_FILE=58
+    - php: 7.3
+      env: PU_FILE=6
+    - php: 7.3
+      env: PU_FILE=7
+    - php: 7.4
+      env: PU_FILE=54
+    - php: 7.4
+      env: PU_FILE=55
+    - php: 7.4
+      env: PU_FILE=56
+    - php: 7.4
+      env: PU_FILE=57
+    - php: 7.4
+      env: PU_FILE=58
+    - php: 7.4
+      env: PU_FILE=6
+    - php: 7.4
+      env: PU_FILE=7
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 before_install:
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:
-  - composer install
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-dist
 
-script: ./vendor/bin/phpunit --configuration phpunit.xml
+script:
+  - ./tests/pu-${PU_FILE}.sh

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.2.0",
         "illuminate/support": "^5.3 || ^6.0 || ^7.0",
         "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
         "endclothing/prometheus_client_php": "^1.0.2 || 1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
-        "mockery/mockery": "^0.9.5",
+        "phpunit/phpunit": "^8.0",
+        "mockery/mockery": "^1.0",
         "friendsofphp/php-cs-fixer": "2.*",
-        "orchestra/testbench": "^3.3"
+        "orchestra/testbench": "^5.0"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
 >
     <testsuites>
         <testsuite name="laravel-prometheus-exporter/tests">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/DatabaseServiceProvider.php
+++ b/src/DatabaseServiceProvider.php
@@ -24,7 +24,7 @@ class DatabaseServiceProvider extends ServiceProvider
                 $querySql,
                 $type
             ]));
-            $this->app->get('prometheus.sql.histogram')->observe($query->time, $labels);
+            $this->app->make('prometheus.sql.histogram')->observe($query->time, $labels);
         });
     }
 

--- a/tests/DatabaseServiceProviderTest.php
+++ b/tests/DatabaseServiceProviderTest.php
@@ -20,14 +20,14 @@ class DatabaseServiceProviderTest extends TestCase
         $this->createTestTable();
 
         /* @var \Prometheus\Histogram $histogram */
-        $histogram = $this->app->get('prometheus.sql.histogram');
+        $histogram = $this->app->make('prometheus.sql.histogram');
         $this->assertInstanceOf(Histogram::class, $histogram);
         $this->assertSame(['query', 'query_type'], $histogram->getLabelNames());
         $this->assertSame('app_sql_query_duration', $histogram->getName());
         $this->assertSame('SQL query duration histogram', $histogram->getHelp());
 
         /* @var PrometheusExporter $prometheus */
-        $prometheus = $this->app->get('prometheus');
+        $prometheus = $this->app->make('prometheus');
         $export = $prometheus->export();
         $this->assertCount(1, $export);
 
@@ -41,16 +41,16 @@ class DatabaseServiceProviderTest extends TestCase
 
     public function testServiceProviderWithoutCollectingFullSqlQueries()
     {
-        $this->app->get('config')->set('prometheus.collect_full_sql_query', false);
+        $this->app->make('config')->set('prometheus.collect_full_sql_query', false);
         $this->createTestTable();
 
         /* @var \Prometheus\Histogram $histogram */
-        $histogram = $this->app->get('prometheus.sql.histogram');
+        $histogram = $this->app->make('prometheus.sql.histogram');
         $this->assertInstanceOf(Histogram::class, $histogram);
         $this->assertSame(['query_type'], $histogram->getLabelNames());
 
         /* @var PrometheusExporter $prometheus */
-        $prometheus = $this->app->get('prometheus');
+        $prometheus = $this->app->make('prometheus');
         $export = $prometheus->export();
         $this->assertCount(1, $export);
 

--- a/tests/DatabaseServiceProviderTest.php
+++ b/tests/DatabaseServiceProviderTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types = 1);
 
-namespace Arquivei\LaravelPrometheusExporter;
+namespace Tests;
 
+use Arquivei\LaravelPrometheusExporter\DatabaseServiceProvider;
+use Arquivei\LaravelPrometheusExporter\PrometheusServiceProvider;
 use Illuminate\Support\Facades\Schema;
-use Orchestra\Testbench\TestCase;
 use Prometheus\Histogram;
 use Prometheus\MetricFamilySamples;
 

--- a/tests/GuzzleMiddlewareTest.php
+++ b/tests/GuzzleMiddlewareTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types = 1);
 
-namespace Arquivei\LaravelPrometheusExporter;
+namespace Tests;
 
+use Arquivei\LaravelPrometheusExporter\GuzzleMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
-use PHPUnit\Framework\TestCase;
 use Prometheus\Histogram;
 
 class GuzzleMiddlewareTest extends TestCase

--- a/tests/GuzzleServiceProviderTest.php
+++ b/tests/GuzzleServiceProviderTest.php
@@ -21,17 +21,17 @@ class GuzzleServiceProviderTest extends TestCase
 {
     public function testServiceProvidersShouldHaveCorrectClasses() : void
     {
-        $this->assertInstanceOf(Client::class, $this->app->get('prometheus.guzzle.client'));
-        $this->assertInstanceOf(CurlHandler::class, $this->app->get('prometheus.guzzle.handler'));
-        $this->assertInstanceOf(GuzzleMiddleware::class, $this->app->get('prometheus.guzzle.middleware'));
-        $this->assertInstanceOf(HandlerStack::class, $this->app->get('prometheus.guzzle.handler-stack'));
-        $this->assertInstanceOf(Histogram::class, $this->app->get('prometheus.guzzle.client.histogram'));
+        $this->assertInstanceOf(Client::class, $this->app->make('prometheus.guzzle.client'));
+        $this->assertInstanceOf(CurlHandler::class, $this->app->make('prometheus.guzzle.handler'));
+        $this->assertInstanceOf(GuzzleMiddleware::class, $this->app->make('prometheus.guzzle.middleware'));
+        $this->assertInstanceOf(HandlerStack::class, $this->app->make('prometheus.guzzle.handler-stack'));
+        $this->assertInstanceOf(Histogram::class, $this->app->make('prometheus.guzzle.client.histogram'));
     }
 
     public function testHistogramShouldHaveCorrectData()
     {
         /* @var \Prometheus\Histogram $histogram */
-        $histogram = $this->app->get('prometheus.guzzle.client.histogram');
+        $histogram = $this->app->make('prometheus.guzzle.client.histogram');
         $this->assertInstanceOf(Histogram::class, $histogram);
         $this->assertSame(['method', 'external_endpoint', 'status_code'], $histogram->getLabelNames());
         $this->assertSame('app_guzzle_response_duration', $histogram->getName());
@@ -45,7 +45,7 @@ class GuzzleServiceProviderTest extends TestCase
             return new MockHandler([$response]);
         });
         /* @var Client $guzzleClient */
-        $guzzleClient = $this->app->get('prometheus.guzzle.client');
+        $guzzleClient = $this->app->make('prometheus.guzzle.client');
         $response = $guzzleClient->request('GET', '/');
         $this->assertNotEmpty($response);
     }

--- a/tests/GuzzleServiceProviderTest.php
+++ b/tests/GuzzleServiceProviderTest.php
@@ -2,14 +2,16 @@
 
 declare(strict_types = 1);
 
-namespace Arquivei\LaravelPrometheusExporter;
+namespace Tests;
 
+use Arquivei\LaravelPrometheusExporter\GuzzleMiddleware;
+use Arquivei\LaravelPrometheusExporter\GuzzleServiceProvider;
+use Arquivei\LaravelPrometheusExporter\PrometheusServiceProvider;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use Orchestra\Testbench\TestCase;
 use Prometheus\Histogram;
 
 /**

--- a/tests/MetricsControllerTest.php
+++ b/tests/MetricsControllerTest.php
@@ -4,13 +4,12 @@ declare(strict_types = 1);
 
 namespace Tests;
 
-use Illuminate\Routing\ResponseFactory;
-use Illuminate\Http\Response;
-use Mockery;
-use PHPUnit\Framework\TestCase;
-use Prometheus\RenderTextFormat;
 use Arquivei\LaravelPrometheusExporter\MetricsController;
 use Arquivei\LaravelPrometheusExporter\PrometheusExporter;
+use Illuminate\Http\Response;
+use Illuminate\Routing\ResponseFactory;
+use Mockery;
+use Prometheus\RenderTextFormat;
 
 /**
  * @covers \Arquivei\LaravelPrometheusExporter\MetricsController<extended>

--- a/tests/PrometheusExporterTest.php
+++ b/tests/PrometheusExporterTest.php
@@ -4,14 +4,13 @@ declare(strict_types = 1);
 
 namespace Tests;
 
+use Arquivei\LaravelPrometheusExporter\CollectorInterface;
+use Arquivei\LaravelPrometheusExporter\PrometheusExporter;
 use Mockery;
-use PHPUnit\Framework\TestCase;
 use Prometheus\CollectorRegistry;
 use Prometheus\Counter;
 use Prometheus\Gauge;
 use Prometheus\Histogram;
-use Arquivei\LaravelPrometheusExporter\CollectorInterface;
-use Arquivei\LaravelPrometheusExporter\PrometheusExporter;
 
 class PrometheusExporterTest extends TestCase
 {

--- a/tests/PrometheusServiceProviderTest.php
+++ b/tests/PrometheusServiceProviderTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types = 1);
 
-namespace Arquivei\LaravelPrometheusExporter;
+namespace Tests;
 
-use Orchestra\Testbench\TestCase;
+use Arquivei\LaravelPrometheusExporter\PrometheusExporter;
+use Arquivei\LaravelPrometheusExporter\PrometheusServiceProvider;
+use Arquivei\LaravelPrometheusExporter\StorageAdapterFactory;
 use Prometheus\Storage\Adapter;
 
 /**

--- a/tests/PrometheusServiceProviderTest.php
+++ b/tests/PrometheusServiceProviderTest.php
@@ -20,9 +20,9 @@ class PrometheusServiceProviderTest extends TestCase
         $this->assertInstanceOf(PrometheusExporter::class, $this->app[PrometheusExporter::class]);
         $this->assertInstanceOf(StorageAdapterFactory::class, $this->app[StorageAdapterFactory::class]);
 
-        $this->assertInstanceOf(Adapter::class, $this->app->get('prometheus.storage_adapter'));
-        $this->assertInstanceOf(PrometheusExporter::class, $this->app->get('prometheus'));
-        $this->assertInstanceOf(StorageAdapterFactory::class, $this->app->get('prometheus.storage_adapter_factory'));
+        $this->assertInstanceOf(Adapter::class, $this->app->make('prometheus.storage_adapter'));
+        $this->assertInstanceOf(PrometheusExporter::class, $this->app->make('prometheus'));
+        $this->assertInstanceOf(StorageAdapterFactory::class, $this->app->make('prometheus.storage_adapter_factory'));
 
         /* @var \Illuminate\Support\Facades\Route $router */
         $router = $this->app['router'];

--- a/tests/RouteMiddlewareTest.php
+++ b/tests/RouteMiddlewareTest.php
@@ -2,11 +2,10 @@
 
 declare(strict_types = 1);
 
-namespace Arquivei\LaravelPrometheusExporter;
+namespace Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use PHPUnit\Framework\TestCase;
 use Prometheus\Histogram;
 
 class RouteMiddlewareTest extends TestCase

--- a/tests/RouteMiddlewareTest.php
+++ b/tests/RouteMiddlewareTest.php
@@ -6,7 +6,9 @@ namespace Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Mockery;
 use Prometheus\Histogram;
+use Symfony\Component\Routing\Route;
 
 class RouteMiddlewareTest extends TestCase
 {
@@ -18,10 +20,10 @@ class RouteMiddlewareTest extends TestCase
             $value = $time;
             $labels = $data;
         };
-        $histogram = \Mockery::mock(Histogram::class);
+        $histogram = Mockery::mock(Histogram::class);
         $histogram->shouldReceive('observe')->andReturnUsing($observe);
 
-        $prometheus = \Mockery::mock(PrometheusExporter::class);
+        $prometheus = Mockery::mock(PrometheusExporter::class);
         $prometheus->shouldReceive('getOrRegisterHistogram')->andReturn($histogram);
         app()['prometheus'] = $prometheus;
 
@@ -31,10 +33,10 @@ class RouteMiddlewareTest extends TestCase
             return $expectedResponse;
         };
 
-        $matchedRouteMock = \Mockery::mock(\Symfony\Component\Routing\Route::class);
+        $matchedRouteMock = Mockery::mock(Route::class);
         $matchedRouteMock->shouldReceive('uri')->andReturn('/test/route');
 
-        $middleware = \Mockery::mock('Arquivei\LaravelPrometheusExporter\PrometheusLumenRouteMiddleware[getMatchedRoute]');
+        $middleware = Mockery::mock('Arquivei\LaravelPrometheusExporter\PrometheusLumenRouteMiddleware[getMatchedRoute]');
         $middleware->shouldReceive('getMatchedRoute')->andReturn($matchedRouteMock);
         $actualResponse = $middleware->handle($request, $next);
 

--- a/tests/StorageAdapterFactoryTest.php
+++ b/tests/StorageAdapterFactoryTest.php
@@ -4,12 +4,11 @@ declare(strict_types = 1);
 
 namespace Tests;
 
+use Arquivei\LaravelPrometheusExporter\StorageAdapterFactory;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
 use Prometheus\Storage\APC;
 use Prometheus\Storage\InMemory;
 use Prometheus\Storage\Redis;
-use Arquivei\LaravelPrometheusExporter\StorageAdapterFactory;
 
 /**
  * @covers \Arquivei\LaravelPrometheusExporter\StorageAdapterFactory<extended>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests;
+
+use Arquivei\LaravelPrometheusExporter\DatabaseServiceProvider;
+use Arquivei\LaravelPrometheusExporter\GuzzleServiceProvider;
+use Arquivei\LaravelPrometheusExporter\PrometheusServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+class TestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            DatabaseServiceProvider::class,
+            GuzzleServiceProvider::class,
+            PrometheusServiceProvider::class,
+       	];
+    }
+}

--- a/tests/pu-53.sh
+++ b/tests/pu-53.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-53.xml
+
+composer require "illuminate/routing:5.3.*" --no-update
+composer require "illuminate/support:5.3.*" --no-update
+composer require "orchestra/testbench:3.3.*" --no-update --dev
+composer require "phpunit/phpunit:5.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-53.xml
+RETVAL=$?
+rm phpunit-53.xml
+
+exit ${RETVAL}

--- a/tests/pu-54.sh
+++ b/tests/pu-54.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-54.xml
+
+composer require "illuminate/routing:5.4.*" --no-update
+composer require "illuminate/support:5.4.*" --no-update
+composer require "orchestra/testbench:3.4.*" --no-update --dev
+composer require "phpunit/phpunit:5.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-54.xml
+RETVAL=$?
+rm phpunit-54.xml
+
+exit ${RETVAL}

--- a/tests/pu-55.sh
+++ b/tests/pu-55.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-55.xml
+
+composer require "illuminate/routing:5.5.*" --no-update
+composer require "illuminate/support:5.5.*" --no-update
+composer require "orchestra/testbench:3.5.*" --no-update --dev
+composer require "phpunit/phpunit:6.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-55.xml
+RETVAL=$?
+rm phpunit-55.xml
+
+exit ${RETVAL}

--- a/tests/pu-56.sh
+++ b/tests/pu-56.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-56.xml
+
+composer require "illuminate/routing:5.6.*" --no-update
+composer require "illuminate/support:5.6.*" --no-update
+composer require "orchestra/testbench:3.6.*" --no-update --dev
+composer require "phpunit/phpunit:7.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-56.xml
+RETVAL=$?
+rm phpunit-56.xml
+
+exit ${RETVAL}

--- a/tests/pu-57.sh
+++ b/tests/pu-57.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-57.xml
+
+composer require "illuminate/routing:5.7.*" --no-update
+composer require "illuminate/support:5.7.*" --no-update
+composer require "orchestra/testbench:3.7.*" --no-update --dev
+composer require "phpunit/phpunit:7.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-57.xml
+RETVAL=$?
+rm phpunit-57.xml
+
+exit ${RETVAL}

--- a/tests/pu-58.sh
+++ b/tests/pu-58.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-58.xml
+
+composer require "illuminate/routing:5.8.*" --no-update
+composer require "illuminate/support:5.8.*" --no-update
+composer require "orchestra/testbench:3.8.*" --no-update --dev
+composer require "phpunit/phpunit:8.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-58.xml
+RETVAL=$?
+rm phpunit-58.xml
+
+exit ${RETVAL}

--- a/tests/pu-6.sh
+++ b/tests/pu-6.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-6.xml
+
+composer require "illuminate/routing:6.*" --no-update
+composer require "illuminate/support:6.*" --no-update
+composer require "orchestra/testbench:4.*" --no-update --dev
+composer require "phpunit/phpunit:8.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-6.xml
+RETVAL=$?
+rm phpunit-6.xml
+
+exit ${RETVAL}

--- a/tests/pu-7.sh
+++ b/tests/pu-7.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cp composer.json original-composer.json
+sed '/        <log type="coverage-html" target="coverage" showUncoveredFiles="true"\/>/d' phpunit.xml > phpunit-7.xml
+
+composer require "illuminate/routing:7.*" --no-update
+composer require "illuminate/support:7.*" --no-update
+composer require "orchestra/testbench:5.*" --no-update --dev
+composer require "phpunit/phpunit:8.*" --no-update --dev
+composer update --no-interaction --prefer-dist
+
+rm composer.json
+mv original-composer.json composer.json
+
+vendor/bin/phpunit --configuration phpunit-7.xml
+RETVAL=$?
+rm phpunit-7.xml
+
+exit ${RETVAL}


### PR DESCRIPTION
Many of the Laravel versions supported by this package still work with PHP 7.2.0 and endclothing/prometheus_client_php also works with PHP 7.2.0. Bumping minimum required language version also seems like a major change and would constitute a major version change rather than a minor version change.

In addition, no specific PHP 7.3 only changes were introduced between 1.0.6 and 1.1.0, so there should not be any issue with reverting back to >=7.2.0.