### PR TITLE
Add configuration for buckets time bounds

### DIFF
--- a/config/prometheus.php
+++ b/config/prometheus.php
@@ -98,4 +98,19 @@ return [
     'collectors' => [
         // \Your\ExporterClass::class,
     ],
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Buckets config
+    |--------------------------------------------------------------------------
+    |
+    | The buckets config specified here will be passed to the histogram generator
+    | in the prometheus client. You can configure it as an array of time bounds.
+    | Default value is null.
+    |
+    */
+    
+    'routes_buckets' => null,
+    'sql_buckets' => null,
+    'guzzle_buckets' => null,
 ];

--- a/src/DatabaseServiceProvider.php
+++ b/src/DatabaseServiceProvider.php
@@ -42,7 +42,8 @@ class DatabaseServiceProvider extends ServiceProvider
                 array_values(array_filter([
                     'query',
                     'query_type'
-                ]))
+                ])),
+                config('prometheus.sql_buckets') ?? null
             );
         });
     }

--- a/src/GuzzleServiceProvider.php
+++ b/src/GuzzleServiceProvider.php
@@ -22,7 +22,8 @@ class GuzzleServiceProvider extends ServiceProvider
             return $app['prometheus']->getOrRegisterHistogram(
                 'guzzle_response_duration',
                 'Guzzle response duration histogram',
-                ['method', 'external_endpoint', 'status_code']
+                ['method', 'external_endpoint', 'status_code'],
+                config('prometheus.guzzle_buckets') ?? null
             );
         });
         $this->app->singleton('prometheus.guzzle.handler', function ($app) {

--- a/src/PrometheusLaravelRouteMiddleware.php
+++ b/src/PrometheusLaravelRouteMiddleware.php
@@ -35,7 +35,8 @@ class PrometheusLaravelRouteMiddleware
                 'method',
                 'route',
                 'status_code',
-            ]
+            ],
+            config('prometheus.guzzle_buckets') ?? null
         );
         /** @var  Histogram $histogram */
         $histogram->observe(


### PR DESCRIPTION
I put three new config variables used to configure the buckets bounds in database, guzzle and routes metrics.