### PR TITLE
Add new Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "illuminate/support": "^5.3 || ^6.0",
-        "illuminate/routing": "^5.3 || ^6.0",
-        "endclothing/prometheus_client_php": "^1.0.2"
+        "illuminate/support": "^5.3 || ^6.0 || ^7.0",
+        "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
+        "endclothing/prometheus_client_php": "^1.0.2 || 1.0.x-dev"
     },
     "repositories": [
         {


### PR DESCRIPTION
At the moment isn't possible to use Laravel 7 (conflicts-wise)

Annotation "|| ^7.0" was added for both "illuminate/support" and "illuminate/routing". Besides that also the annotation "|| 1.0.x-dev" was added for "endclothing/prometheus_client_php" usage itself in order to make a compatible combination of versions