### PR TITLE
Add redis-ng storage adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   "require": {
     "php": "^8.0 || ^8.1 || ^8.2",
     "guzzlehttp/guzzle": "^7.4.2",
-    "illuminate/routing": "^10.0",
-    "illuminate/support": "^10.0",
+    "illuminate/routing": "^10.0 || ^11.0",
+    "illuminate/support": "^10.0 || ^11.0",
     "promphp/prometheus_client_php": "^2.6.0"
   },
   "require-dev": {

--- a/src/PrometheusServiceProvider.php
+++ b/src/PrometheusServiceProvider.php
@@ -35,6 +35,10 @@ class PrometheusServiceProvider extends ServiceProvider
             $prometheus = new CollectorRegistry($adapter, true);
             $exporter = new PrometheusExporter(config('prometheus.namespace'), $prometheus);
             foreach (config('prometheus.collectors') as $collectorClass) {
+                if(empty($collectorClass)){
+                    continue;
+                }
+
                 $collector = $this->app->make($collectorClass);
                 $exporter->registerCollector($collector);
             }

--- a/src/StorageAdapterFactory.php
+++ b/src/StorageAdapterFactory.php
@@ -63,8 +63,7 @@ class StorageAdapterFactory
     protected function makeRedisNgAdapter(array $config) : RedisNg
     {
         if (isset($config['prefix'])) {
-            $prefix = !empty($config['prefix_dynamic']) ? sprintf('%s_%s_', $config['prefix'], $this->hostname) : $config['prefix'];
-            RedisNg::setPrefix($prefix);
+            RedisNg::setPrefix($config['prefix']);
         }
 
         return new RedisNg($config);

--- a/src/StorageAdapterFactory.php
+++ b/src/StorageAdapterFactory.php
@@ -9,6 +9,7 @@ use Prometheus\Storage\Adapter;
 use Prometheus\Storage\APC;
 use Prometheus\Storage\InMemory;
 use Prometheus\Storage\Redis;
+use Prometheus\Storage\RedisNg;
 
 class StorageAdapterFactory
 {
@@ -34,6 +35,8 @@ class StorageAdapterFactory
                 return new InMemory();
             case 'redis':
                 return $this->makeRedisAdapter($config);
+            case 'redis-ng':
+                return $this->makeRedisNgAdapter($config);
             case 'apc':
                 return new APC();
         }
@@ -56,5 +59,22 @@ class StorageAdapterFactory
         }
 
         return new Redis($config);
+    }
+
+    /**
+     * Factory a redis-ng storage adapter.
+     *
+     * @param array $config
+     *
+     * @return RedisNg
+     */
+    protected function makeRedisNgAdapter(array $config) : RedisNg
+    {
+        if (isset($config['prefix'])) {
+            $prefix = !empty($config['prefix_dynamic']) ? sprintf('%s_%s_', $config['prefix'], $this->hostname) : $config['prefix'];
+            RedisNg::setPrefix($prefix);
+        }
+
+        return new RedisNg($config);
     }
 }


### PR DESCRIPTION
Added possibility to use redis-ng Prometheus adapter, not only Redis. Highly important for databases with lots of keys/metrics.