### PR TITLE
Restore compatibility with Laravel 12 and PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
+    "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
     "guzzlehttp/guzzle": "^7.4.2",
     "illuminate/routing": "^12.0",
     "illuminate/support": "^12.0",
@@ -17,7 +17,7 @@
   "require-dev": {
     "phpunit/phpunit": "^12.0.0",
     "mockery/mockery": "^1.5.0",
-    "orchestra/testbench": "^9.0"
+    "orchestra/testbench": "^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/RouteMiddlewareTest.php
+++ b/tests/RouteMiddlewareTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 use Orchestra\Testbench\TestCase;
+use Prometheus\Counter;
 use Prometheus\Histogram;
 
 class RouteMiddlewareTest extends TestCase
@@ -22,27 +23,39 @@ class RouteMiddlewareTest extends TestCase
             $labels = $data;
         };
         $histogram = \Mockery::mock(Histogram::class);
-        $histogram->shouldReceive('observe')->andReturnUsing($observe);
+        $histogram->shouldReceive('observe')->once()->andReturnUsing($observe);
+
+        $counter = \Mockery::mock(Counter::class);
+        $counter->shouldReceive('inc')->andReturn(null);
+
+        $latencyHistogram = \Mockery::mock(Histogram::class);
+        $latencyHistogram->shouldReceive('observe')->andReturn(null);
 
         $prometheus = \Mockery::mock(PrometheusExporter::class);
         $prometheus->shouldReceive('getOrRegisterHistogram')->andReturn($histogram);
+        $prometheus->shouldReceive('getOrRegisterNamelessCounter')->andReturn($counter);
+        $prometheus->shouldReceive('getOrRegisterNamelessHistogram')->andReturn($latencyHistogram);
         app()['prometheus'] = $prometheus;
 
         $request = new Request();
         $expectedResponse = new Response();
-        $next = function (Request $request) use ($expectedResponse) {
+        $minimumRequestDurationUs = 10_000;
+        $minimumRequestDurationS = $minimumRequestDurationUs / 1_000_000;
+        $next = function (Request $request) use ($expectedResponse, $minimumRequestDurationUs) {
+            usleep($minimumRequestDurationUs); // min 10us request duration for testing
             return $expectedResponse;
         };
 
         $matchedRouteMock = \Mockery::mock(Route::class);
         $matchedRouteMock->shouldReceive('uri')->andReturn('/test/route');
+        $matchedRouteMock->shouldReceive('getActionName')->andReturn('TestController@testAction');
 
         $middleware = \Mockery::mock('Arquivei\LaravelPrometheusExporter\PrometheusLumenRouteMiddleware[getMatchedRoute]');
         $middleware->shouldReceive('getMatchedRoute')->andReturn($matchedRouteMock);
         $actualResponse = $middleware->handle($request, $next);
 
         $this->assertSame($expectedResponse, $actualResponse);
-        $this->assertGreaterThan(0, $value);
+        $this->assertGreaterThan($minimumRequestDurationS, $value, 'Duration must be greater than simulated delay');
         $this->assertSame(['GET', '/test/route', 200], $labels);
     }
 }


### PR DESCRIPTION
## Description:

This PR adds support for Laravel 12 and PHP 8.4

### Changes:

**Dependencies update:**
- ✅ Added PHP 8.4 support (`^8.4`)
- ✅ Updated `orchestra/testbench` dependency from `^9.0` to `^10.0` for Laravel 12 compatibility

**Test fixes:**
- ✅ Fixed `RouteMiddlewareTest` to work correctly with Laravel 12
- ✅ Added missing mocks for `Counter` and `Histogram` classes
- ✅ Improved test logic by adding minimum request duration for more stable testing

### Testing:
- All tests pass successfully on Laravel 12
- Fixed instability in route middleware tests

___
Closes #50

@ricardokovalski Please take a look when you have a moment 🙏 
Let me know if you would like to make any further improvements.