### PR TITLE
fix: alinha orchestra/testbench ao Laravel 12 (^10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require-dev": {
     "phpunit/phpunit": "^12.0.0",
     "mockery/mockery": "^1.5.0",
-    "orchestra/testbench": "^9.0"
+    "orchestra/testbench": "^10.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Contexto

O PR #48 adicionou suporte a Laravel 12 (`illuminate/* ^12.0`) mas deixou `orchestra/testbench` em `^9.0` (Laravel 11), deixando as dev deps **irresolvíveis** em L12 (`composer install` conflita).

## Mudança

- `orchestra/testbench: ^9.0` → `^10.0` (Laravel 12).

## Validação

`composer update` resolve em Laravel 12.64 + testbench 10.11 + phpunit 12.5 (PHP 8.4).

## Nota

A suíte de testes do repo já estava vermelha no master antes desta mudança (asserts stale em `RouteMiddlewareTest`, `ext-redis` no `StorageAdapterFactoryTest`) — débito pré-existente, fora do escopo deste PR. Este PR apenas destrava a resolução das dev deps para permitir release com suporte a L12.